### PR TITLE
InputView adaptive lines based on the UITextView

### DIFF
--- a/Example/Chat Input/CustomChatInput.swift
+++ b/Example/Chat Input/CustomChatInput.swift
@@ -23,6 +23,7 @@ class CustomChatInput: UIChatInput {
         let nib = UINib(nibName: "CustomChatInput", bundle: Bundle.main)
         super.commonInit(nib: nib)
         self.tvInput.delegate = self
+        self.setInputViewMaxLines(with: 10, basedOn: tvInput)
     }
     
     @IBAction func clickSend(_ sender: Any) {
@@ -50,24 +51,26 @@ class CustomChatInput: UIChatInput {
     }
     
     /**
+     * for advance size customization
      * UIChatInput are also implement UITextViewDelegate if you are using UITextView as your input view no need to conforming UITextViewDelegate on this custom class
      * if you want custom behavior or need another UITextViewDelegate function simply just write the UITextViewDelegate function or override the function if its also implemented in UIChatInput like the (textViewDidEndEditing, textViewDidBeginEditing, textViewDidChange)
      **/
-    override func textViewDidEndEditing(_ textView: UITextView) {
-        self.typing(false)
-    }
-    
-    override func textViewDidBeginEditing(_ textView: UITextView) {
-        self.typing(true)
-    }
-    
-    override func textViewDidChange(_ textView: UITextView) {
-        let fontHeight = textView.font?.lineHeight
-        let line = textView.contentSize.height / fontHeight!
-        
-        if line < 4 {
-            self.frame = self.calculateHeight()
-            self.layoutIfNeeded()
-        }
-    }
+//    override func textViewDidEndEditing(_ textView: UITextView) {
+//        self.typing(false)
+//    }
+//
+//    override func textViewDidBeginEditing(_ textView: UITextView) {
+//        self.typing(true)
+//    }
+//
+//
+//    override func textViewDidChange(_ textView: UITextView) {
+//        let fontHeight = textView.font?.lineHeight
+//        let line = textView.contentSize.height / fontHeight!
+//
+//        if line < 4 {
+//            self.frame = self.calculateHeight()
+//            self.layoutIfNeeded()
+//        }
+//    }
 }

--- a/Example/Chat Input/CustomChatInput.swift
+++ b/Example/Chat Input/CustomChatInput.swift
@@ -16,37 +16,58 @@ protocol CustomChatInputDelegate {
 
 class CustomChatInput: UIChatInput {
     
-    @IBOutlet weak var textField: UITextField!
+    @IBOutlet weak var tvInput: UITextView!
     var delegate : CustomChatInputDelegate? = nil
     
     override func commonInit(nib: UINib) {
         let nib = UINib(nibName: "CustomChatInput", bundle: Bundle.main)
         super.commonInit(nib: nib)
-        self.textField.delegate = self
+        self.tvInput.delegate = self
     }
     
     @IBAction func clickSend(_ sender: Any) {
-        guard let text = self.textField.text else {return}
+        guard let text = self.tvInput.text else {return}
         if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let comment = CommentModel()
             comment.type = "text"
             comment.message = text
             self.send(message: comment)
         }
-        self.textField.text = ""
+        self.tvInput.text = ""
     }
     
     @IBAction func clickAttachment(_ sender: Any) {
         self.delegate?.sendAttachment()
     }
-}
-
-extension CustomChatInput: UITextFieldDelegate {
-    func textFieldDidBeginEditing(_ textField: UITextField) {
+    
+    private func calculateHeight() -> CGRect {
+        var tvInputFrame = tvInput.frame
+        tvInputFrame.size.height = tvInput.contentSize.height + 2
+        
+        var inputContainerFrame = self.frame
+        inputContainerFrame.size.height = tvInput.contentSize.height + 10
+        return inputContainerFrame
+    }
+    
+    /**
+     * UIChatInput are also implement UITextViewDelegate if you are using UITextView as your input view no need to conforming UITextViewDelegate on this custom class
+     * if you want custom behavior or need another UITextViewDelegate function simply just write the UITextViewDelegate function or override the function if its also implemented in UIChatInput like the (textViewDidEndEditing, textViewDidBeginEditing, textViewDidChange)
+     **/
+    override func textViewDidEndEditing(_ textView: UITextView) {
+        self.typing(false)
+    }
+    
+    override func textViewDidBeginEditing(_ textView: UITextView) {
         self.typing(true)
     }
     
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        self.typing(false)
+    override func textViewDidChange(_ textView: UITextView) {
+        let fontHeight = textView.font?.lineHeight
+        let line = textView.contentSize.height / fontHeight!
+        
+        if line < 4 {
+            self.frame = self.calculateHeight()
+            self.layoutIfNeeded()
+        }
     }
 }

--- a/Example/Chat Input/CustomChatInput.xib
+++ b/Example/Chat Input/CustomChatInput.xib
@@ -12,7 +12,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CustomChatInput" customModule="Example" customModuleProvider="target">
             <connections>
-                <outlet property="textField" destination="oKn-dc-97b" id="DpP-mX-jRf"/>
+                <outlet property="tvInput" destination="NXN-hw-uv1" id="HpR-AD-Jqj"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -31,38 +31,6 @@
                         <action selector="clickSend:" destination="-1" eventType="touchUpInside" id="npz-r2-1Hv"/>
                     </connections>
                 </button>
-                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oKn-dc-97b">
-                    <rect key="frame" x="50" y="10" width="275" height="30"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="30" id="pls-dj-Rw7"/>
-                    </constraints>
-                    <nil key="textColor"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <textInputTraits key="textInputTraits"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadiuss">
-                            <real key="value" value="15"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidths">
-                            <real key="value" value="1"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="leftBorderWidth">
-                            <real key="value" value="1"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="topBorderWidth">
-                            <real key="value" value="1"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="rightBorderWidth">
-                            <real key="value" value="1"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="bottomBorderWidth">
-                            <real key="value" value="1"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
-                            <color key="value" red="0.82533193010000006" green="0.82533193010000006" blue="0.82533193010000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
-                </textField>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eX8-dS-8SK">
                     <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                     <constraints>
@@ -75,17 +43,24 @@
                         <action selector="clickAttachment:" destination="-1" eventType="touchUpInside" id="kun-jy-4MV"/>
                     </connections>
                 </button>
+                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="NXN-hw-uv1">
+                    <rect key="frame" x="58" y="10" width="259" height="30"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                </textView>
             </subviews>
             <color key="backgroundColor" red="0.93725490570000003" green="0.93725490570000003" blue="0.95686274770000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="KIv-HR-J1D" firstAttribute="centerY" secondItem="k7R-ZU-AZb" secondAttribute="centerY" id="B81-XS-cGF"/>
                 <constraint firstAttribute="height" constant="50" id="DLU-RV-8pF"/>
-                <constraint firstItem="KIv-HR-J1D" firstAttribute="leading" secondItem="oKn-dc-97b" secondAttribute="trailing" id="Sb7-zE-kua"/>
-                <constraint firstItem="eX8-dS-8SK" firstAttribute="top" secondItem="8Om-te-Qpk" secondAttribute="top" id="Soi-Or-XJR"/>
-                <constraint firstItem="eX8-dS-8SK" firstAttribute="bottom" secondItem="8Om-te-Qpk" secondAttribute="bottom" id="WqX-8J-v5r"/>
+                <constraint firstItem="NXN-hw-uv1" firstAttribute="top" secondItem="8Om-te-Qpk" secondAttribute="top" constant="10" id="Lg3-01-yEf"/>
+                <constraint firstItem="eX8-dS-8SK" firstAttribute="bottom" secondItem="8Om-te-Qpk" secondAttribute="bottom" id="N8P-ua-APx"/>
+                <constraint firstItem="8Om-te-Qpk" firstAttribute="bottom" secondItem="NXN-hw-uv1" secondAttribute="bottom" constant="10" id="O4h-Hw-yMs"/>
+                <constraint firstItem="NXN-hw-uv1" firstAttribute="centerY" secondItem="8Om-te-Qpk" secondAttribute="centerY" id="Pr8-lJ-Nas"/>
+                <constraint firstItem="KIv-HR-J1D" firstAttribute="bottom" secondItem="8Om-te-Qpk" secondAttribute="bottom" id="QLu-fL-FGS"/>
                 <constraint firstItem="eX8-dS-8SK" firstAttribute="leading" secondItem="8Om-te-Qpk" secondAttribute="leading" id="gOG-2e-H61"/>
-                <constraint firstItem="oKn-dc-97b" firstAttribute="leading" secondItem="eX8-dS-8SK" secondAttribute="trailing" id="rYO-7g-a3Z"/>
-                <constraint firstItem="oKn-dc-97b" firstAttribute="centerY" secondItem="k7R-ZU-AZb" secondAttribute="centerY" id="wC6-nm-XnY"/>
+                <constraint firstItem="NXN-hw-uv1" firstAttribute="leading" secondItem="eX8-dS-8SK" secondAttribute="trailing" constant="8" id="ovW-JN-GXl"/>
+                <constraint firstItem="KIv-HR-J1D" firstAttribute="leading" secondItem="NXN-hw-uv1" secondAttribute="trailing" constant="8" id="w31-fr-0gD"/>
                 <constraint firstAttribute="trailing" secondItem="KIv-HR-J1D" secondAttribute="trailing" id="zAX-l7-ZVv"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/QiscusUI/Controllers/Chat Input/UIChatInput.swift
+++ b/QiscusUI/Controllers/Chat Input/UIChatInput.swift
@@ -35,8 +35,9 @@ open class UIChatInput: UIView {
         }
     }
     private var _delegate       : UIChatInputDelegate? = nil
+    private var inputToBeCalculated: UITextView?
+    private var inputViewMaxLines: CGFloat = 4
     var contentsView            : UIView!
-    
     var onHeightChange: (CGFloat) -> Void = { _ in }
     open override var frame: CGRect {
         didSet {
@@ -80,6 +81,12 @@ open class UIChatInput: UIView {
         }
     }
     
+    // set maxLines based on external UITextView (sorry my shortcut to create documentation doesn't work, i don't know why)
+    open func setInputViewMaxLines(with lines: CGFloat, basedOn view: UITextView) {
+        self.inputViewMaxLines = lines
+        self.inputToBeCalculated = view
+    }
+    
     @IBAction private func clickUISendButton(_ sender: Any) {
         guard let text = self.tvInput?.text else {return}
         if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -92,16 +99,27 @@ open class UIChatInput: UIView {
     }
     
     private func calculateHeight() -> CGRect {
-        if let inputView = tvInput {
-            var tvInputFrame = inputView.frame
-            tvInputFrame.size.height = inputView.contentSize.height + 2
-            
-            var inputContainerFrame = self.frame
-            inputContainerFrame.size.height = inputView.contentSize.height + 10
-            return inputContainerFrame
+        
+        if let customInputView = self.inputToBeCalculated {
+            // do calculation based on custom view by client app
+            return self.getInputHeight(inputView: customInputView)
+        } else {
+            // do calculation based default input view
+            if let inputView = tvInput {
+                return self.getInputHeight(inputView: inputView)
+            }
         }
         
         return CGRect()
+    }
+    
+    private func getInputHeight(inputView: UITextView) -> CGRect {
+        var tvInputFrame = inputView.frame
+        tvInputFrame.size.height = inputView.contentSize.height + 2
+        
+        var inputContainerFrame = self.frame
+        inputContainerFrame.size.height = inputView.contentSize.height + 10
+        return inputContainerFrame
     }
 }
 
@@ -110,7 +128,7 @@ extension UIChatInput : UITextViewDelegate {
         let fontHeight = textView.font?.lineHeight
         let line = textView.contentSize.height / fontHeight!
         
-        if line < 4 {
+        if line < inputViewMaxLines {
             self.frame = self.calculateHeight()
             self.layoutIfNeeded()
         }

--- a/QiscusUI/Controllers/Chat Input/UIChatInput.swift
+++ b/QiscusUI/Controllers/Chat Input/UIChatInput.swift
@@ -22,9 +22,10 @@ protocol UIChatInputDelegate {
 
 open class UIChatInput: UIView {
 
+    @IBOutlet weak var tvInput: UITextView?
     @IBOutlet weak var btnAttachment: UIButton!
     @IBOutlet weak var btnSend: UIButton!
-    @IBOutlet weak var tfInput: UITextField!
+
     var delegate : UIChatInputDelegate? {
         set {
             self._delegate = newValue
@@ -35,6 +36,13 @@ open class UIChatInput: UIView {
     }
     private var _delegate       : UIChatInputDelegate? = nil
     var contentsView            : UIView!
+    
+    var onHeightChange: (CGFloat) -> Void = { _ in }
+    open override var frame: CGRect {
+        didSet {
+            onHeightChange(frame.height)
+        }
+    }
 
     // If someone is to initialize a UIChatInput in code
     public override init(frame: CGRect) {
@@ -67,17 +75,53 @@ open class UIChatInput: UIView {
         contentsView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
         
         self.autoresizingMask  = (UIViewAutoresizing.flexibleWidth)
+        if let input = self.tvInput {
+            input.delegate = self
+        }
     }
     
     @IBAction private func clickUISendButton(_ sender: Any) {
-        guard let text = self.tfInput.text else {return}
+        guard let text = self.tvInput?.text else {return}
         if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let message = CommentModel()
             message.message = text
             message.type    = "text"
             self._delegate?.send(message: message)
         }
-        self.tfInput.text = ""
+        self.tvInput?.text = ""
+    }
+    
+    private func calculateHeight() -> CGRect {
+        if let inputView = tvInput {
+            var tvInputFrame = inputView.frame
+            tvInputFrame.size.height = inputView.contentSize.height + 2
+            
+            var inputContainerFrame = self.frame
+            inputContainerFrame.size.height = inputView.contentSize.height + 10
+            return inputContainerFrame
+        }
+        
+        return CGRect()
+    }
+}
+
+extension UIChatInput : UITextViewDelegate {
+    open func textViewDidChange(_ textView: UITextView) {
+        let fontHeight = textView.font?.lineHeight
+        let line = textView.contentSize.height / fontHeight!
+        
+        if line < 4 {
+            self.frame = self.calculateHeight()
+            self.layoutIfNeeded()
+        }
+    }
+    
+    open func textViewDidBeginEditing(_ textView: UITextView) {
+        self._delegate?.typing(true)
+    }
+    
+    open func textViewDidEndEditing(_ textView: UITextView) {
+        self._delegate?.typing(false)
     }
 }
 

--- a/QiscusUI/Controllers/Chat Input/UIChatInput.xib
+++ b/QiscusUI/Controllers/Chat Input/UIChatInput.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -13,7 +13,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UIChatInput" customModule="QiscusUI" customModuleProvider="target">
             <connections>
                 <outlet property="btnSend" destination="QQt-h9-LIp" id="Wk4-cC-Gb8"/>
-                <outlet property="tfInput" destination="ZSi-gt-c6K" id="gJJ-nh-Jc1"/>
+                <outlet property="tvInput" destination="YfP-fM-y60" id="S0c-Xh-1xK"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -31,44 +31,19 @@
                         <action selector="clickUISendButton:" destination="-1" eventType="touchUpInside" id="uej-hI-By2"/>
                     </connections>
                 </button>
-                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZSi-gt-c6K">
-                    <rect key="frame" x="10" y="10" width="315" height="30"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="30" id="vUz-z5-DMU"/>
-                    </constraints>
-                    <nil key="textColor"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <textInputTraits key="textInputTraits"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadiuss">
-                            <real key="value" value="15"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidths">
-                            <real key="value" value="1"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="leftBorderWidth">
-                            <real key="value" value="1"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="topBorderWidth">
-                            <real key="value" value="1"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="rightBorderWidth">
-                            <real key="value" value="1"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="bottomBorderWidth">
-                            <real key="value" value="1"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
-                            <color key="value" red="0.82533193010000006" green="0.82533193010000006" blue="0.82533193010000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
-                </textField>
+                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="YfP-fM-y60">
+                    <rect key="frame" x="16" y="6" width="301" height="38"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                </textView>
             </subviews>
             <color key="backgroundColor" red="0.95191062179999997" green="0.95191062179999997" blue="0.95191062179999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="ZSi-gt-c6K" firstAttribute="leading" secondItem="QzY-bx-oqA" secondAttribute="leading" constant="10" id="6AA-3Q-JRr"/>
-                <constraint firstItem="QQt-h9-LIp" firstAttribute="leading" secondItem="ZSi-gt-c6K" secondAttribute="trailing" id="8Rb-gD-Dbe"/>
-                <constraint firstItem="ZSi-gt-c6K" firstAttribute="centerY" secondItem="0MB-aY-CqT" secondAttribute="centerY" id="elW-yf-trW"/>
+                <constraint firstItem="YfP-fM-y60" firstAttribute="top" secondItem="QzY-bx-oqA" secondAttribute="top" constant="6" id="Apm-Pt-Dve"/>
+                <constraint firstItem="YfP-fM-y60" firstAttribute="leading" secondItem="QzY-bx-oqA" secondAttribute="leading" constant="16" id="Naq-Tw-tbi"/>
+                <constraint firstItem="QzY-bx-oqA" firstAttribute="bottom" secondItem="YfP-fM-y60" secondAttribute="bottom" constant="6" id="OTB-oP-Rd0"/>
+                <constraint firstItem="QQt-h9-LIp" firstAttribute="leading" secondItem="YfP-fM-y60" secondAttribute="trailing" constant="8" id="Yf9-9d-w3J"/>
                 <constraint firstAttribute="height" constant="50" id="iLV-9u-TRU"/>
                 <constraint firstItem="QQt-h9-LIp" firstAttribute="centerY" secondItem="0MB-aY-CqT" secondAttribute="centerY" id="jNP-6V-j2G"/>
                 <constraint firstAttribute="trailing" secondItem="QQt-h9-LIp" secondAttribute="trailing" id="vnn-kL-Ff5"/>
@@ -86,10 +61,10 @@
                     <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </userDefinedRuntimeAttribute>
             </userDefinedRuntimeAttributes>
-            <point key="canvasLocation" x="220" y="-436"/>
+            <point key="canvasLocation" x="219.5" y="-436"/>
         </view>
     </objects>
     <resources>
-        <image name="send" width="28" height="28"/>
+        <image name="send" width="21" height="21"/>
     </resources>
 </document>

--- a/QiscusUI/Controllers/Chat View/UIChatViewController.swift
+++ b/QiscusUI/Controllers/Chat View/UIChatViewController.swift
@@ -49,8 +49,8 @@ class DateHeaderLabel: UILabel {
 open class UIChatViewController: UIViewController {
     @IBOutlet weak var tableViewConversation: UITableView!
     @IBOutlet weak var viewChatInput: UIView!
-    @IBOutlet weak var viewInput: NSLayoutConstraint!
     @IBOutlet weak var constraintViewInputBottom: NSLayoutConstraint!
+    @IBOutlet weak var constraintViewInputHeight: NSLayoutConstraint!
     public var titleLabel = UILabel()
     public var subtitleLabel = UILabel()
     private var subtitleText:String = ""
@@ -144,6 +144,10 @@ open class UIChatViewController: UIViewController {
         inputchatview.frame.size    = self.viewChatInput.frame.size
         inputchatview.frame.origin  = CGPoint.init(x: 0, y: 0)
         inputchatview.delegate = self
+        
+        inputchatview.onHeightChange = { [weak self] height in
+            self?.constraintViewInputHeight.constant = height
+        }
         self.viewChatInput.addSubview(inputchatview)
     }
     

--- a/QiscusUI/Controllers/Chat View/UIChatViewController.xib
+++ b/QiscusUI/Controllers/Chat View/UIChatViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -13,10 +13,10 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UIChatViewController" customModule="QiscusUI" customModuleProvider="target">
             <connections>
                 <outlet property="constraintViewInputBottom" destination="AVd-I5-3cz" id="5XK-Jf-2YL"/>
+                <outlet property="constraintViewInputHeight" destination="JR1-fH-mcK" id="xAU-8d-HkN"/>
                 <outlet property="tableViewConversation" destination="DF6-Lu-tNz" id="n8q-S5-uDs"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
                 <outlet property="viewChatInput" destination="XjR-Mj-c6H" id="7c0-sB-u7H"/>
-                <outlet property="viewInput" destination="XjR-Mj-c6H" id="TBQ-yD-cnU"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>


### PR DESCRIPTION
for quick solution you can use

class CustomChatInput: UIChatInput {
    @IBOutlet weak var tvInput: UITextView!
   
    override func commonInit(nib: UINib) {
        let nib = UINib(nibName: "CustomChatInput", bundle: Bundle.main)
        super.commonInit(nib: nib)

        self.tvInput.delegate = self
        self.setInputViewMaxLines(with: 10, basedOn: tvInput)
    }
}

this two function will handle the calculation
        self.tvInput.delegate = self
        self.setInputViewMaxLines(with: 10, basedOn: tvInput)

for more size customization  you can do your own calculation and listening to UITextView delegate. Since UIChatInput already conforming the UITextViewDelegate no need to make your custom class to conforming the UITextViewDelegate. just simply write the UITextViewDelegate based on your requirement.

for example, you can do like this

    override func textViewDidEndEditing(_ textView: UITextView) {
        self.typing(false)
    }

    override func textViewDidBeginEditing(_ textView: UITextView) {
        self.typing(true)
    }

    override func textViewDidChange(_ textView: UITextView) {
        let fontHeight = textView.font?.lineHeight
        let line = textView.contentSize.height / fontHeight!

        if line < 4 {
            self.frame = self.calculateHeight()
            self.layoutIfNeeded()
        }
    }

those three function are also used in UIChatInput so you need to override it, no need to call super since you will do your own calculation. Another UITextViewDelegate function are also available just write it no need to override (only those three UITextViewDelegate that need to be overrided)
